### PR TITLE
Add ConfigMap and Secret environment variables test

### DIFF
--- a/vktestset/templates/080-configmap-secret-env.yaml
+++ b/vktestset/templates/080-configmap-secret-env.yaml
@@ -1,0 +1,174 @@
+## ConfigMap and Secret Environment Variables
+##
+## Tests environment variable injection from:
+##  * ConfigMaps using configMapKeyRef
+##  * Secrets using secretKeyRef
+## 
+## This validates that the virtual kubelet properly implements
+## ConfigMap and Secret environment variable references.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config-{{ uuid }}
+  namespace: {{ namespace }}
+data:
+  app-name: "config-test-app"
+  app-version: "1.0.0"
+  environment: "test"
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret-{{ uuid }}
+  namespace: {{ namespace }}
+type: Opaque
+stringData:
+  api-key: "secret-api-key-12345"
+  database-password: "super-secret-password"
+  token: "bearer-token-xyz789"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: configmap-secret-test-{{ uuid }}
+  namespace: {{ namespace }}
+  annotations: {{ annotations | tojson }}
+  labels:
+    app: configmap-secret-test
+    version: "1.0"
+    test-id: "{{ uuid }}"
+
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    kubernetes.io/hostname: {{ target_node }}
+
+  containers:
+  - name: configmap-secret-container
+    image: python:alpine
+    command: ["python", "-c"]
+    args:
+      - |
+        import os
+        import time
+        
+        print("=== ConfigMap Environment Variables ===")
+        config_vars = ['APP_NAME', 'APP_VERSION', 'ENVIRONMENT']
+        for var in config_vars:
+            value = os.environ.get(var, 'NOT_SET')
+            print(f"{var}: {value}")
+        
+        print("\n=== Secret Environment Variables ===")
+        secret_vars = ['API_KEY', 'DB_PASSWORD', 'AUTH_TOKEN']
+        for var in secret_vars:
+            value = os.environ.get(var, 'NOT_SET')
+            print(f"{var}: {value}")
+        
+        print("=== Test completed ===")
+
+    env:
+      # Environment variables from ConfigMap
+      - name: APP_NAME
+        valueFrom:
+          configMapKeyRef:
+            name: test-config-{{ uuid }}
+            key: app-name
+      - name: APP_VERSION
+        valueFrom:
+          configMapKeyRef:
+            name: test-config-{{ uuid }}
+            key: app-version
+      - name: ENVIRONMENT
+        valueFrom:
+          configMapKeyRef:
+            name: test-config-{{ uuid }}
+            key: environment
+      
+      # Environment variables from Secret
+      - name: API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: test-secret-{{ uuid }}
+            key: api-key
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: test-secret-{{ uuid }}
+            key: database-password
+      - name: AUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: test-secret-{{ uuid }}
+            key: token
+
+    imagePullPolicy: Always
+    
+  dnsPolicy: ClusterFirst
+  tolerations: {{ tolerations | tojson }}
+
+################################################################################
+# VALIDATION
+timeout_seconds: 15
+check_pods: 
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+
+check_logs: 
+  # Verify ConfigMap environment variables
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "APP_NAME: config-test-app"
+    operator: Exists
+
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "APP_VERSION: 1.0.0"
+    operator: Exists
+
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "ENVIRONMENT: test"
+    operator: Exists
+
+  # Verify Secret environment variables
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "API_KEY: secret-api-key-12345"
+    operator: Exists
+
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "DB_PASSWORD: super-secret-password"
+    operator: Exists
+
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "AUTH_TOKEN: bearer-token-xyz789"
+    operator: Exists
+
+  # Verify test completion
+  - name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    regex: "Test completed"
+    operator: Exists
+
+clean_configs:
+  - type: pod
+    name: configmap-secret-test-{{ uuid }}
+    namespace: {{ namespace }}
+    condition: onSuccess
+
+  - type: config_map
+    name: test-config-{{ uuid }}
+    namespace: {{ namespace }}
+    condition: always
+
+  - type: secret
+    name: test-secret-{{ uuid }}
+    namespace: {{ namespace }}
+    condition: always


### PR DESCRIPTION
## Summary
- Clean, focused test template for ConfigMap and Secret environment variable injection
- Tests `configMapKeyRef` with comprehensive ConfigMap data:
  - `app-name: "config-test-app"`
  - `app-version: "1.0.0"`
  - `environment: "test"`
- Tests `secretKeyRef` with comprehensive Secret data:
  - `api-key: "secret-api-key-12345"`
  - `database-password: "super-secret-password"`
  - `token: "bearer-token-xyz789"`
- Comprehensive validation of all environment variable values
- Clean test output showing ConfigMap and Secret values separately
- No external dependencies (no Downward API, no volumes)

## Test plan
- [ ] Verify template creates pods without validation errors
- [ ] Confirm all ConfigMap environment variables are populated correctly
- [ ] Confirm all Secret environment variables are populated correctly
- [ ] Validate against virtual kubelet implementation

This provides a focused test for the most common environment variable injection patterns using ConfigMaps and Secrets, ensuring maximum compatibility across different virtual kubelet implementations.

References interlink-hq/interLink#438

🤖 Generated with [Claude Code](https://claude.ai/code)